### PR TITLE
feat(detail): เติม Data Log จาก BE + ปรับ UI ให้แสดง N/A ตามกติกา

### DIFF
--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,18 +1,18 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Card({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-4 rounded-xl border p-6 shadow-sm",
         className
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
@@ -25,7 +25,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
@@ -35,7 +35,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("leading-none font-semibold", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
@@ -45,7 +45,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("text-muted-foreground text-sm", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardAction({ className, ...props }: React.ComponentProps<"div">) {
@@ -58,7 +58,7 @@ function CardAction({ className, ...props }: React.ComponentProps<"div">) {
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardContent({ className, ...props }: React.ComponentProps<"div">) {
@@ -68,7 +68,7 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("px-6", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
@@ -78,7 +78,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -89,4 +89,4 @@ export {
   CardAction,
   CardDescription,
   CardContent,
-}
+};

--- a/src/features/dashboard-admin/components/DetailDataLog.tsx
+++ b/src/features/dashboard-admin/components/DetailDataLog.tsx
@@ -71,7 +71,7 @@ export default function DetailDataLog({
     <div className="space-y-4">
       {/* ID Card Data */}
       <SectionFrame title="ID Card Data" className="border-0 p-0 shadow-none">
-        <div className="rounded-[12px] bg-[#F9FAFC] px-4 py-6 space-y-4">
+        <div className="rounded-xs py-6 px-4 bg-[#F9FAFC] space-y-4">
           <NameCompareBlock
             title="THAI"
             original={dataLog.idCard?.thaiOriginalName}
@@ -89,7 +89,7 @@ export default function DetailDataLog({
 
       {/* Book Bank Data */}
       <SectionFrame title="Book Bank Data" className="border-0 p-0 shadow-none">
-        <div className="rounded-[12px] bg-[#F9FAFC] px-4 py-6 space-y-4">
+        <div className="rounded-xs px-4 py-6 bg-[#F9FAFC] space-y-4">
           <NameCompareBlock
             title="THAI"
             original={dataLog.bankBook?.thaiOriginalName}
@@ -121,7 +121,7 @@ function SectionFrame({
 }) {
   return (
     <Card className={cn("p-4", className)}>
-      <h3 className="mb-3 font-medium text-lg">{title}</h3>
+      <h3 className="font-medium text-xl">{title}</h3>
       {children}
     </Card>
   );
@@ -138,47 +138,50 @@ function NameCompareBlock({
   edited?: string | null;
   percent?: number | null;
 }) {
-  const badge = percentBadge(percent);
+  const badge = percent != null ? percentBadge(percent) : null;
+  const displayEdited = percent === 100 ? null : edited;
 
   return (
-    <div className="rounded-lg bg-white/60 p-3">
-      <p className="mb-3 font-medium">{title}</p>
-
-      {/* แถวข้อมูล: label ซ้าย / value ขวา (truncate) */}
+    <div className="space-y-4">
+      <p className="text-sm font-medium">{title}</p>
       <Row label="Original name" value={original} />
-      <Row label="Edited name" value={edited} />
-
-      {/* แถวคะแนนความเหมือน */}
-      <div className="mt-2 flex items-center justify-between">
-        <p className="text-xs text-muted-foreground">Similarity Score</p>
-        <Badge
-          className={cn(
-            "border-none px-2 py-0.5 text-sm font-normal rounded-full",
-            badge.className
-          )}
-        >
-          {badge.text}
-        </Badge>
+      <Row label="Edited name" value={displayEdited} />
+      <div className=" flex items-center justify-between">
+        <p className="text-sm text-[#646464]">Similarity Score</p>
+        {badge ? (
+          <Badge
+            className={cn(
+              "border-none px-2 py-0.5 text-sm font-normal rounded-full",
+              badge.className
+            )}
+          >
+            {badge.text}
+          </Badge>
+        ) : (
+          <span className="text-sm text-[#212121]">N/A</span>
+        )}
       </div>
     </div>
   );
 }
 
 function Row({ label, value }: { label: string; value?: string | null }) {
+  const display = value && value.trim() !== "" ? value : "N/A";
   return (
     <div className="flex items-center justify-between">
-      <p className="text-xs text-muted-foreground">{label}</p>
-      <p className="ml-4 max-w-[60%] truncate text-sm">
-        {value && value.trim() !== "" ? value : "-"}
+      <p className="text-sm text-[#646464]">{label}</p>
+      <p className="ml-4 font-normal text-sm text-[#212121]">
+        {display}
       </p>
     </div>
   );
 }
 
 /** กำหนดสี/ข้อความของ Badge ตามช่วงเปอร์เซ็นต์ */
-function percentBadge(
-  pct?: number | null
-): { text: string; className: string } {
+function percentBadge(pct?: number | null): {
+  text: string;
+  className: string;
+} {
   if (pct == null || Number.isNaN(pct)) {
     return { text: "-", className: "bg-muted text-muted-foreground" };
   }

--- a/src/features/dashboard-admin/components/DetailView.tsx
+++ b/src/features/dashboard-admin/components/DetailView.tsx
@@ -164,6 +164,41 @@ function fromApiToDetailVM(api: KycRequestApi): DetailVM {
     coalesceName(api.idcardEdit?.firstNameEng, api.idcardEdit?.lastNameEng) ??
     coalesceName(api.idcardOrigin?.firstNameEng, api.idcardOrigin?.lastNameEng);
 
+  // ===== DataLog mapping =====
+  const idThaiOriginal =
+    coalesceName(
+      api.idcardOrigin?.firstNameThai,
+      api.idcardOrigin?.lastNameThai
+    ) ?? null;
+  const idThaiEdited =
+    coalesceName(api.idcardEdit?.firstNameThai, api.idcardEdit?.lastNameThai) ??
+    null;
+  const idThaiPct: number | null = api.idcardThaiNameMatchPercent ?? null;
+  const idThaiEditedForUI = idThaiPct === 100 ? null : idThaiEdited;
+
+  const idEngOriginal =
+    coalesceName(
+      api.idcardOrigin?.firstNameEng,
+      api.idcardOrigin?.lastNameEng
+    ) ?? null;
+  const idEngEdited =
+    coalesceName(api.idcardEdit?.firstNameEng, api.idcardEdit?.lastNameEng) ??
+    null;
+  const idEngPct: number | null = api.idcardEnglishNameMatchPercent ?? null;
+  const idEngEditedForUI = idEngPct === 100 ? null : idEngEdited;
+
+  const bbThaiOriginal: string | null =
+    api.bookbankOrigin?.accountNameThai ?? null;
+  const bbThaiEdited: string | null = api.bookbankEdit?.accountNameThai ?? null;
+  const bbThaiPct: number | null = api.bookbankThaiNameMatchPercent ?? null;
+  const bbThaiEditedForUI = bbThaiPct === 100 ? null : bbThaiEdited;
+
+  const bbEngOriginal: string | null =
+    api.bookbankOrigin?.accountNameEng ?? null;
+  const bbEngEdited: string | null = api.bookbankEdit?.accountNameEng ?? null;
+  const bbEngPct: number | null = api.bookbankEnglishNameMatchPercent ?? null;
+  const bbEngEditedForUI = bbEngPct === 100 ? null : bbEngEdited;
+
   return {
     requestId: api.id,
     transactionNo: api.correlationId ?? undefined,
@@ -197,7 +232,24 @@ function fromApiToDetailVM(api: KycRequestApi): DetailVM {
     branch: api.bookbankEdit?.branchName ?? null,
     bankNameMatch: computeBankNameMatch(api),
 
-    dataLog: null,
+    dataLog: {
+      idCard: {
+        thaiOriginalName: idThaiOriginal,
+        thaiEditedName: idThaiEditedForUI,
+        thaiSimilarityPercent: idThaiPct,
+        engOriginalName: idEngOriginal,
+        engEditedName: idEngEditedForUI,
+        engSimilarityPercent: idEngPct,
+      },
+      bankBook: {
+        thaiOriginalName: bbThaiOriginal,
+        thaiEditedName: bbThaiEditedForUI,
+        thaiSimilarityPercent: bbThaiPct,
+        engOriginalName: bbEngOriginal,
+        engEditedName: bbEngEditedForUI,
+        engSimilarityPercent: bbEngPct,
+      },
+    },
   };
 }
 
@@ -223,15 +275,15 @@ function StatusBadge({ status }: { status?: UiStatus }) {
 }
 
 function fmtDate(iso?: string | null) {
-  if (!iso) return "-";
+  if (!iso) return "N/A";
   const d = new Date(iso);
-  return isNaN(d.getTime()) ? "-" : d.toLocaleDateString();
+  return isNaN(d.getTime()) ? "N/A" : d.toLocaleDateString();
 }
 
 function gradeConfidence(
   pct: number | null | undefined
-): "High" | "Moderate" | "Low" | "-" {
-  if (pct == null) return "-";
+): "High" | "Moderate" | "Low" | "N/A" {
+  if (pct == null) return "N/A";
   if (pct >= 85) return "High";
   if (pct >= 65) return "Moderate";
   return "Low";
@@ -248,7 +300,7 @@ function Field({
     <div className="flex items-center justify-between w-full ">
       <span className="text-xs font-normal">{label}</span>
       <span className="text-sm font-normal ml-4 text-right truncate max-w-[60%]">
-        {value ?? "-"}
+        {value ?? "N/A"}
       </span>
     </div>
   );
@@ -370,7 +422,7 @@ function VerificationStatusBanner({ status }: { status?: UiStatus }) {
             Verification Status
           </p>
           <p className={cn("text-sm text-normal text-black")}>
-            Status : <span className={cn(T.textLink)}>{status ?? "-"}</span>
+            Status : <span className={cn(T.textLink)}>{status ?? "N/A"}</span>
           </p>
         </div>
       </div>
@@ -666,7 +718,7 @@ export default function DetailView({
     // ใช้ _id สำหรับ body และ companyId สำหรับ path
     const requestId = resolvedDetail?.requestId ?? data?.id ?? "";
     const companyId = data?.companyId ?? "";
-    const tx = resolvedDetail?.transactionNo ?? data?.correlationId ?? "-";
+    const tx = resolvedDetail?.transactionNo ?? data?.correlationId ?? "N/A";
 
     // แปลง action → สถานะ backend + คำนวณสถานะใหม่บน UI
     const apiStatus = actionToApiStatus(kind, currentStatus);
@@ -794,8 +846,8 @@ export default function DetailView({
   React.useEffect(() => {
     if (!open) return;
 
-    const tx = resolvedDetail?.transactionNo ?? data?.correlationId ?? "-";
-    const vis = visibleStatus ?? "-";
+    const tx = resolvedDetail?.transactionNo ?? data?.correlationId ?? "N/A";
+    const vis = visibleStatus ?? "N/A";
 
     // ==== กลุ่มสรุปสถานะโดยรวม ====
     console.groupCollapsed(`🔎 DetailView opened: tx=${tx} status=${vis}`);
@@ -893,7 +945,7 @@ export default function DetailView({
 
   React.useEffect(() => {
     if (!confirm) return;
-    const tx = resolvedDetail?.transactionNo ?? data?.correlationId ?? "-";
+    const tx = resolvedDetail?.transactionNo ?? data?.correlationId ?? "N/A";
     console.log(`🧾 ConfirmDialog: kind=${confirm} tx=${tx}`);
   }, [confirm, resolvedDetail, data]);
 
@@ -1075,7 +1127,7 @@ export default function DetailView({
                         {(() => {
                           const pct = resolvedDetail.faceMatchPercent ?? null;
                           const pctText =
-                            pct != null ? `${Math.round(pct)}%` : "-";
+                            pct != null ? `${Math.round(pct)}%` : "N/A";
                           const grade = gradeConfidence(pct);
 
                           const pctColor =
@@ -1154,7 +1206,7 @@ export default function DetailView({
                         label="Name Matching"
                         value={
                           resolvedDetail.bankNameMatch == null ? (
-                            "-"
+                            "N/A"
                           ) : (
                             <Badge
                               className={cn(


### PR DESCRIPTION

  <!-- E.g  [WEB] implement-pull-request-template -->
 
##
 
### Related : JIRA []
 
<!-- Explain for detail this PR -->
 
## Change Description
- ใช้เปอร์เซ็นต์จาก BE ใน mapper (fromApiToDetailVM):
  - idcardThaiNameMatchPercent, idcardEnglishNameMatchPercent
  - bookbankThaiNameMatchPercent, bookbankEnglishNameMatchPercent
  - กติกา: ถ้า percent === 100 ⇒ Edited = N/A
- แมพค่า origin/edit ของทั้ง TH/ENG สำหรับ ID Card และ Book Bank
- ปรับ UI Data Log:
  - ช่องที่ไม่มีข้อมูลแสดง "N/A"
  - Similarity Score ไม่มีค่า ⇒ แสดง "N/A"
  - กันพลาด: ถ้า percent === 100 บังคับ Edited แสดง N/A ที่ UI ด้วย

Files changed:
- src/features/dashboard-admin/components/DetailView.tsx
  * เติมบล็อกแมพ dataLog ภายใน fromApiToDetailVM
- src/features/dashboard-admin/components/DetailDataLog.tsx
  * Row(): แสดง N/A
  * NameCompareBlock(): แสดง N/A ให้ Similarity Score เมื่อไม่มีค่า และ force N/A เมื่อ percent === 100## What kind of change ?
 
- [x] New feature.
- [ ] Bug fix.
- [ ] Code improvement.
- [ ] Service deployment.
- [ ] Release.
- [ ] FixDate.
 
## Is this a breaking change ?
 
- [ ] Yes
- [x] No
 
## Test Evidence
<img width="471" height="456" alt="image" src="https://github.com/user-attachments/assets/fa327fec-f8ae-450f-9b04-b86e1f62c49e" />
<img width="459" height="463" alt="image" src="https://github.com/user-attachments/assets/517113e6-4dbb-41e8-a21c-ad9ef813b00b" />

<!-- NOTE -->