### PR TITLE
fix(images): robust storage URL builder w/ HTTPS auto-proxy fallback

### DIFF
--- a/src/features/dashboard-admin/helpers/mappers.ts
+++ b/src/features/dashboard-admin/helpers/mappers.ts
@@ -10,21 +10,31 @@ const STORAGE_BASE: string =
     "http://141.11.156.52:3208/storage/files/"
   ).replace(/\/+$/, "") + "/";
 
-/** สร้าง URL สำหรับไฟล์จาก MinIO
- * - ถ้าใช้ proxy (/api/storage/files/) → ห้าม encode "/" (ให้เป็น path segments)
- * - ถ้าเรียกตรง MinIO → ต้อง encode ทั้งสตริง ("/" → "%2F")
- */
+/** same-origin proxy prefix ที่เราสร้างไว้: /api/storage/files/[...path] */
+const PROXY_BASE = "/api/storage/files/";
+
+/** สร้าง URL ไปหารูป โดยเลือกเส้นทางที่ปลอดภัยอัตโนมัติ */
 function buildStorageUrl(filename?: string | null): string | null {
   if (!filename || filename.trim() === "") return null;
+
   const base = STORAGE_BASE.replace(/\/+$/, "") + "/";
 
-  // ✅ เคส proxy ของเรา: ไม่ encode "/" เพื่อให้ router จับ [...path] ได้ถูก
-  if (base.startsWith("/api/storage/files/")) {
-    // ตัวอย่างผลลัพธ์: /api/storage/files/68db.../face/verify/xxx.jpg
+  // 1) ถ้าใช้พร็อกซีของแอปอยู่แล้ว → อย่า encode '/'
+  if (base.startsWith(PROXY_BASE)) {
+    // ตัวอย่าง: /api/storage/files/68db.../face/verify/file.jpg
     return base + filename;
   }
 
-  // ✅ เคสเรียกตรง MinIO: ต้อง encode ทั้ง path ("/" → "%2F")
+  // 2) ถ้าหน้าเว็บเป็น HTTPS แต่ base เป็น HTTP → บังคับผ่านพร็อกซี เพื่อกัน mixed content
+  if (
+    typeof window !== "undefined" &&
+    window.location.protocol === "https:" &&
+    base.startsWith("http://")
+  ) {
+    return PROXY_BASE + filename;
+  }
+
+  // 3) ยิงตรง MinIO → ต้อง encode ทั้ง path ("/" → "%2F")
   return base + encodeURIComponent(filename);
 }
 


### PR DESCRIPTION
- mappers.ts (buildStorageUrl):
  - use app proxy (/api/storage/files/) without encoding slashes
  - if page is HTTPS but base is HTTP, route via proxy automatically
  - keep direct MinIO path with encodeURIComponent as fallback